### PR TITLE
Add a Max/MSP MingW target

### DIFF
--- a/makefile
+++ b/makefile
@@ -25,6 +25,23 @@ PDNTLIB = /NODEFAULTLIB:libcmt /NODEFAULTLIB:oldnames /NODEFAULTLIB:kernel32 \
 	cl $(PDNTCFLAGS) $(PDNTINCLUDE) /c $*.c
 	link /nologo /dll /export:$(CSYM)_setup $*.obj $(PDNTLIB)
 
+# ----------------------- MINGW -----------------------
+
+max_mingw: $(NAME).mxe
+
+.SUFFIXES: .mxe
+
+LIBMAPPER_CFLAGS = $(shell pkg-config --cflags libmapper-0)
+LIBMAPPER_LIBS = $(shell pkg-config --libs libmapper-0)
+
+PDMINGWCFLAGS = -DMAXMSP -DWIN_VERSION -DWIN_EXT_VERSION $(LIBMAPPER_CFLAGS)
+PDMINGWINCLUDE = -I$(MAXSDKPATH)/c74support/max-includes
+PDMINGWLIB = -L$(MAXSDKPATH)/c74support/max-includes -lMaxAPI $(LIBMAPPER_LIBS)
+
+.c.mxe:
+	$(CC) $(PDMINGWCFLAGS) $(PDMINGWINCLUDE) -c -o $(<:%.c=%.o) $<
+	$(CC) -shared -o $@ $(<:%.c=%.o) $(<:%.c=%.def) $(PDMINGWLIB)
+
 # ----------------------- IRIX 5.x -----------------------
 
 pd_irix5: $(NAME).pd_irix5

--- a/mapper.c
+++ b/mapper.c
@@ -28,7 +28,9 @@
 #include <string.h>
 #include <math.h>
 #include <lo/lo.h>
-#include <arpa/inet.h>
+#ifndef WIN32
+  #include <arpa/inet.h>
+#endif
 
 #include <unistd.h>
 

--- a/mapper.def
+++ b/mapper.def
@@ -1,0 +1,4 @@
+LIBRARY mapper.mxe
+
+EXPORTS
+	main


### PR DESCRIPTION
Tested against Max runtime 5.1.9 on Windows.
