### PR TITLE
updated .gitignore; compile fat binaries for Pd to both architectures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ mapout/build
 mapin/build
 *.mxo
 *.pd_darwin
+mapper-osx-max-pd*
+oscmulticast

--- a/mapper/makefile
+++ b/mapper/makefile
@@ -110,8 +110,8 @@ LIBMAPPER_CFLAGS = $(shell pkg-config --cflags libmapper)
 LIBMAPPER_LIBS = $(shell pkg-config --libs libmapper)
 
 .c.pd_darwin:
-	$(CC) -arch i386 $(DARWINCFLAGS) $(LINUXINCLUDE) -I /Applications/Pd-extended.app/Contents/Resources/include -o $*.o -c $*.c $(LIBMAPPER_CFLAGS)
-	$(CC) -arch i386 -bundle -undefined suppress -flat_namespace \
+	$(CC) -arch i386 -arch x86_64 $(DARWINCFLAGS) $(LINUXINCLUDE) -I /Applications/Pd-extended.app/Contents/Resources/include -o $*.o -c $*.c $(LIBMAPPER_CFLAGS)
+	$(CC) -arch i386 -arch x86_64 -bundle -undefined suppress -flat_namespace \
 	    -o $*.pd_darwin $*.o $(LIBMAPPER_LIBS)
 	rm -f $*.o
 


### PR DESCRIPTION
updated makefile to produce both 32 and 64 bit versions for pd_darwin. (tested and works with .49-1 of Pd Vanilla on OSX).