### PR TITLE
restored explicit linking of liblo in Xcode project files

### DIFF
--- a/mapdevice/map.device.xcodeproj/project.pbxproj
+++ b/mapdevice/map.device.xcodeproj/project.pbxproj
@@ -198,6 +198,7 @@
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"$(C74_SYM_LINKER_FLAGS)",
+					/usr/local/lib/liblo.dylib,
 					"-lmx",
 					/usr/local/lib/libmapper.dylib,
 				);

--- a/mapin/map.in.xcodeproj/project.pbxproj
+++ b/mapin/map.in.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"$(C74_SYM_LINKER_FLAGS)",
+					/usr/local/lib/liblo.dylib,
 					"-lmx",
 					/usr/local/lib/libmapper.dylib,
 				);

--- a/mapout/map.out.xcodeproj/project.pbxproj
+++ b/mapout/map.out.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"$(C74_SYM_LINKER_FLAGS)",
+					/usr/local/lib/liblo.dylib,
 					"-lmx",
 					/usr/local/lib/libmapper.dylib,
 				);

--- a/mapper/mapper.xcodeproj/project.pbxproj
+++ b/mapper/mapper.xcodeproj/project.pbxproj
@@ -198,6 +198,7 @@
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"$(C74_SYM_LINKER_FLAGS)",
+					/usr/local/lib/liblo.dylib,
 					"-lmx",
 					/usr/local/lib/libmapper.dylib,
 				);


### PR DESCRIPTION
fixes 32 bit Max not loading the externals due to not finding liblo symbols on runtime

this was the xcode project configuration before aa06ac.

not sure if libz needs to be restored as well...